### PR TITLE
BufWritePre fails if file has less than 9 lines error fix

### DIFF
--- a/lua/ft_header/components.lua
+++ b/lua/ft_header/components.lua
@@ -49,6 +49,10 @@ end
 
 function M.ft_update(ops, login)
     local line = util.getline(9)
+    if line == nil
+        then
+        return
+    end
     local index = string.find(line, "Updated")
     if index ~= config.margin + 1
         then


### PR DESCRIPTION
This pull request references issue https://github.com/abellaismail7/42header.nvim/issues/2