### PR TITLE
refactor(readme): added coherence and helpful tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ I assume that you have two env variables:
 
 ```
 $USER="bella" # For your username
-$MAIL="bella@example.com" # For your mail
+$USER_MAIL="bella@example.com" # For your mail
 ```
 
 # Usage
 In Normal mode you can use `:Ftheader`.
 
 you might want to map it to a convient key.
+nvim supplies a list of key notations with the command `:h key-notation`.
 
 ```
 vim.api.nvim_set_keymap('n', '<leader>h', ': Ftheader', {noremap = true})
@@ -33,7 +34,7 @@ vim.api.nvim_set_keymap('n', '<leader>h', ': Ftheader', {noremap = true})
 For auto header update `Updated : ...` you should add this to your config
 
 ```
-vim.cmd("autocmd BufWritePre * call :Ftupdate")
+vim.cmd("autocmd BufWritePre * :Ftupdate")
 ```
 
 For manual update:


### PR DESCRIPTION
Code uses $USER_MAIL instead of $MAIL - https://github.com/abellaismail7/42header.nvim/blob/3d9f16815bc917bd8a2259c1a5efb789ae930a7e/lua/ft_header/util.lua#L16

"autocmd BufWritePre * call :Ftupdate" causes an error since call is to be used only with lua functions, not commands - https://neovim.io/doc/user/autocmd.html

I've also added a mention of the key-notation help file in nvim, to make setting the keymap easier